### PR TITLE
Publish: use single timeout instead of per-subscriber timers

### DIFF
--- a/publisher.go
+++ b/publisher.go
@@ -82,14 +82,26 @@ func (p *Publisher) Publish(v interface{}) {
 		return
 	}
 
+	var t *time.Timer
+	var done chan struct{}
+	if p.timeout > 0 {
+		done = make(chan struct{})
+		t = time.AfterFunc(p.timeout, func() {
+			close(done) // cancel all goroutines
+		})
+	}
+
 	wg := wgPool.Get().(*sync.WaitGroup)
 	for sub, topic := range p.subscribers {
 		wg.Add(1)
-		go p.sendTopic(sub, topic, v, wg)
+		go sendTopic(sub, topic, v, done, wg)
 	}
 	wg.Wait()
-	wgPool.Put(wg)
 	p.m.RUnlock()
+	wgPool.Put(wg)
+	if t != nil {
+		t.Stop()
+	}
 }
 
 // Close closes the channels to all subscribers registered with the publisher.
@@ -102,20 +114,16 @@ func (p *Publisher) Close() {
 	p.m.Unlock()
 }
 
-func (p *Publisher) sendTopic(sub subscriber, topic topicFunc, v interface{}, wg *sync.WaitGroup) {
+func sendTopic(sub subscriber, topic topicFunc, v interface{}, done <-chan struct{}, wg *sync.WaitGroup) {
 	defer wg.Done()
 	if topic != nil && !topic(v) {
 		return
 	}
 
-	// send under a select as to not block if the receiver is unavailable
-	if p.timeout > 0 {
-		timeout := time.NewTimer(p.timeout)
-		defer timeout.Stop()
-
+	if done != nil {
 		select {
 		case sub <- v:
-		case <-timeout.C:
+		case <-done:
 		}
 		return
 	}


### PR DESCRIPTION
- using the benchmarks from https://github.com/moby/pubsub/pull/2

Replace the per-subscriber timer introduced in [moby@434d2e8] (8de872b27f7ae05d724810af84266a273d5e407e) with a single timeout per Publish call.

The original change ([moby@434d2e8]) introduced per-subscriber timeouts to prevent slow subscribers from blocking publishers. A later change (48d7a81e33aac0459aecee1d093507dfe2627707) switched from time.After to time.NewTimer to avoid timer leaks.

This preserves the original protection against slow subscribers while avoiding one timer allocation per subscriber per publish. Although the timeout now acts as a publish-wide deadline rather than a strictly per-subscriber timer, the effective delivery bound remains roughly equivalent in practice.

Before/after:

<details>
<summary>(or as markdown)</summary>

Benchmark | Before (sec/op) | Timer (sec/op) | Δ vs base
-- | -- | -- | --
Publish_NoSubscribers | 5.011n ± 0% | 3.893n ± 13% | -22.32% (p=0.000 n=10)
Publish_1Subscriber | 270.9n ± 1% | 283.5n ± 2% | +4.67% (p=0.000 n=10)
Publish_WithTimeout_1Subscriber | 628.6n ± 1% | 652.8n ± 45% | ~ (p=0.052 n=10)
Publish_10Subscribers | 2.886µ ± 0% | 3.084µ ± 11% | +6.86% (p=0.037 n=10)
Publish_100Subscribers | 31.61µ ± 1% | 31.22µ ± 6% | ~ (p=0.218 n=10)
Publish_1000Subscribers | 375.6µ ± 0% | 372.3µ ± 3% | ~ (p=0.143 n=10)
Publish_WithTimeout_10Subscribers | 5.032µ ± 0% | 3.458µ ± 1% | -31.29% (p=0.000 n=10)
Publish_WithTimeout_100Subscribers | 53.94µ ± 0% | 35.55µ ± 2% | -34.09% (p=0.000 n=10)
Publish_WithTimeout_1000Subscribers | 661.4µ ± 1% | 422.3µ ± 6% | -36.15% (p=0.000 n=10)
Publish_50Subscribers | 16.15µ ± 1% | 17.04µ ± 6% | ~ (p=0.143 n=10)
Publish_WithTimeout_50Subscribers | 28.29µ ± 1% | 18.16µ ± 5% | -35.79% (p=0.000 n=10)
Subscribe | 71.98n ± 4% | 70.40n ± 5% | -2.20% (p=0.023 n=10)
Evict | 161.9n ± 5% | 162.3n ± 1% | ~ (p=0.897 n=10)
Close_1000Subscribers | 44.00µ ± 2% | 44.60µ ± 1% | ~ (p=0.063 n=10)
Subscribe_UnderPublishLoad | 1.075µ ± 4% | 1.122µ ± 10% | ~ (p=0.165 n=10)
Publish_50Subscribers_StatsLike_Value | 16.30µ ± 1% | 16.18µ ± 1% | ~ (p=0.197 n=10)
Publish_WithTimeout_50Subscribers_StatsLike_Value | 28.63µ ± 1% | 18.18µ ± 1% | -36.49% (p=0.000 n=10)
Publish_50Subscribers_StatsLike_Pointer | 16.32µ ± 34% | 16.24µ ± 1% | ~ (p=0.280 n=10)
Publish_WithTimeout_50Subscribers_StatsLike_Pointer | 33.80µ ± 24% | 17.99µ ± 1% | -46.77% (p=0.000 n=10)
SubscribeTopic | 81.06n ± 7% | 74.59n ± 1% | -7.98% (p=0.000 n=10)
Publish_50Subscribers_StatsLike_TopicAssertValue | 21.20µ ± 6% | 20.61µ ± 0% | ~ (p=0.353 n=10)
Publish_WithTimeout_50Subscribers_StatsLike_TopicAssertValue | 33.46µ ± 7% | 22.57µ ± 1% | -32.55% (p=0.000 n=10)
Publish_50Subscribers_StatsLike_TopicAssertPointer | 16.17µ ± 1% | 16.28µ ± 1% | ~ (p=0.165 n=10)
Publish_WithTimeout_50Subscribers_StatsLike_TopicAssertPointer | 28.68µ ± 3% | 18.13µ ± 0% | -36.79% (p=0.000 n=10)
geomean | 6.165µ | 5.268µ | -14.54%

Benchmark | Before (B/op) | Timer (B/op) | Δ vs base
-- | -- | -- | --
Publish_NoSubscribers | 0.000 ± 0% | 0.000 ± 0% | ~
Publish_1Subscriber | 64.00 ± 0% | 64.00 ± 0% | ~
Publish_WithTimeout_1Subscriber | 312.0 ± 0% | 304.0 ± 0% | -2.56% (p=0.000 n=10)
Publish_10Subscribers | 640.0 ± 0% | 640.0 ± 0% | ~
Publish_100Subscribers | 6.250Ki ± 0% | 6.250Ki ± 0% | ~
Publish_1000Subscribers | 62.50Ki ± 0% | 62.50Ki ± 0% | ~
Publish_WithTimeout_10Subscribers | 3120.0 ± 0% | 880.0 ± 0% | -71.79% (p=0.000 n=10)
Publish_WithTimeout_100Subscribers | 30.470Ki ± 0% | 6.484Ki ± 0% | -78.72% (p=0.000 n=10)
Publish_WithTimeout_1000Subscribers | 304.76Ki ± 0% | 62.74Ki ± 0% | -79.41% (p=0.000 n=10)
Publish_50Subscribers | 3.125Ki ± 0% | 3.125Ki ± 0% | ~
Publish_WithTimeout_50Subscribers | 15.234Ki ± 0% | 3.359Ki ± 0% | -77.95% (p=0.000 n=10)
Subscribe | 112.0 ± 0% | 112.0 ± 0% | ~
Evict | 0.000 ± 0% | 0.000 ± 0% | ~
Close_1000Subscribers | 0.000 ± 0% | 0.000 ± 0% | ~
Subscribe_UnderPublishLoad | 260.5 ± 2% | 267.0 ± 9% | ~ (p=0.108 n=10)
Publish_50Subscribers_StatsLike_Value | 3.125Ki ± 0% | 3.125Ki ± 0% | ~
Publish_WithTimeout_50Subscribers_StatsLike_Value | 15.234Ki ± 0% | 3.359Ki ± 0% | -77.95% (p=0.000 n=10)
Publish_50Subscribers_StatsLike_Pointer | 3.125Ki ± 0% | 3.125Ki ± 0% | ~
Publish_WithTimeout_50Subscribers_StatsLike_Pointer | 15.234Ki ± 0% | 3.359Ki ± 0% | -77.95% (p=0.000 n=10)
SubscribeTopic | 112.0 ± 0% | 112.0 ± 0% | ~
Publish_50Subscribers_StatsLike_TopicAssertValue | 9.375Ki ± 0% | 9.375Ki ± 0% | ~
Publish_WithTimeout_50Subscribers_StatsLike_TopicAssertValue | 21.485Ki ± 0% | 9.609Ki ± 0% | -55.27% (p=0.000 n=10)
Publish_50Subscribers_StatsLike_TopicAssertPointer | 3.125Ki ± 0% | 3.125Ki ± 0% | ~
Publish_WithTimeout_50Subscribers_StatsLike_TopicAssertPointer | 15.234Ki ± 0% | 3.359Ki ± 0% | -77.95% (p=0.000 n=10)
geomean | — | — | -37.41%


Benchmark | Before (allocs/op) | Timer (allocs/op) | Δ vs base
-- | -- | -- | --
Publish_NoSubscribers | 0.000 ± 0% | 0.000 ± 0% | ~
Publish_1Subscriber | 1.000 ± 0% | 1.000 ± 0% | ~
Publish_WithTimeout_1Subscriber | 4.000 ± 0% | 4.000 ± 0% | ~
Publish_10Subscribers | 10.00 ± 0% | 10.00 ± 0% | ~
Publish_100Subscribers | 100.0 ± 0% | 100.0 ± 0% | ~
Publish_1000Subscribers | 1.000k ± 0% | 1.000k ± 0% | ~
Publish_WithTimeout_10Subscribers | 40.00 ± 0% | 13.00 ± 0% | -67.50% (p=0.000 n=10)
Publish_WithTimeout_100Subscribers | 400.0 ± 0% | 103.0 ± 0% | -74.25% (p=0.000 n=10)
Publish_WithTimeout_1000Subscribers | 4.000k ± 0% | 1.003k ± 0% | -74.93% (p=0.000 n=10)
Publish_50Subscribers | 50.00 ± 0% | 50.00 ± 0% | ~
Publish_WithTimeout_50Subscribers | 200.00 ± 0% | 53.00 ± 0% | -73.50% (p=0.000 n=10)
Subscribe | 1.000 ± 0% | 1.000 ± 0% | ~
Evict | 0.000 ± 0% | 0.000 ± 0% | ~
Close_1000Subscribers | 0.000 ± 0% | 0.000 ± 0% | ~
Subscribe_UnderPublishLoad | 3.000 ± 0% | 3.000 ± 0% | ~
Publish_50Subscribers_StatsLike_Value | 50.00 ± 0% | 50.00 ± 0% | ~
Publish_WithTimeout_50Subscribers_StatsLike_Value | 200.00 ± 0% | 53.00 ± 0% | -73.50% (p=0.000 n=10)
Publish_50Subscribers_StatsLike_Pointer | 50.00 ± 0% | 50.00 ± 0% | ~
Publish_WithTimeout_50Subscribers_StatsLike_Pointer | 200.00 ± 0% | 53.00 ± 0% | -73.50% (p=0.000 n=10)
SubscribeTopic | 1.000 ± 0% | 1.000 ± 0% | ~
Publish_50Subscribers_StatsLike_TopicAssertValue | 100.0 ± 0% | 100.0 ± 0% | ~
Publish_WithTimeout_50Subscribers_StatsLike_TopicAssertValue | 250.0 ± 0% | 103.0 ± 0% | -58.80% (p=0.000 n=10)
Publish_50Subscribers_StatsLike_TopicAssertPointer | 50.00 ± 0% | 50.00 ± 0% | ~
Publish_WithTimeout_50Subscribers_StatsLike_TopicAssertPointer | 200.00 ± 0% | 53.00 ± 0% | -73.50% (p=0.000 n=10)
geomean | — | — | -34.25%

</details>



```
goos: darwin
goarch: arm64
pkg: github.com/moby/pubsub
cpu: Apple M3 Pro
                                                               │  before.txt  │              timer.txt               │
                                                               │    sec/op    │    sec/op     vs base                │
Publish_NoSubscribers                                            5.011n ±  0%   3.893n ± 13%  -22.32% (p=0.000 n=10)
Publish_1Subscriber                                              270.9n ±  1%   283.5n ±  2%   +4.67% (p=0.000 n=10)
Publish_WithTimeout_1Subscriber                                  628.6n ±  1%   652.8n ± 45%        ~ (p=0.052 n=10)
Publish_10Subscribers                                            2.886µ ±  0%   3.084µ ± 11%   +6.86% (p=0.037 n=10)
Publish_100Subscribers                                           31.61µ ±  1%   31.22µ ±  6%        ~ (p=0.218 n=10)
Publish_1000Subscribers                                          375.6µ ±  0%   372.3µ ±  3%        ~ (p=0.143 n=10)
Publish_WithTimeout_10Subscribers                                5.032µ ±  0%   3.458µ ±  1%  -31.29% (p=0.000 n=10)
Publish_WithTimeout_100Subscribers                               53.94µ ±  0%   35.55µ ±  2%  -34.09% (p=0.000 n=10)
Publish_WithTimeout_1000Subscribers                              661.4µ ±  1%   422.3µ ±  6%  -36.15% (p=0.000 n=10)
Publish_50Subscribers                                            16.15µ ±  1%   17.04µ ±  6%        ~ (p=0.143 n=10)
Publish_WithTimeout_50Subscribers                                28.29µ ±  1%   18.16µ ±  5%  -35.79% (p=0.000 n=10)
Subscribe                                                        71.98n ±  4%   70.40n ±  5%   -2.20% (p=0.023 n=10)
Evict                                                            161.9n ±  5%   162.3n ±  1%        ~ (p=0.897 n=10)
Close_1000Subscribers                                            44.00µ ±  2%   44.60µ ±  1%        ~ (p=0.063 n=10)
Subscribe_UnderPublishLoad                                       1.075µ ±  4%   1.122µ ± 10%        ~ (p=0.165 n=10)
Publish_50Subscribers_StatsLike_Value                            16.30µ ±  1%   16.18µ ±  1%        ~ (p=0.197 n=10)
Publish_WithTimeout_50Subscribers_StatsLike_Value                28.63µ ±  1%   18.18µ ±  1%  -36.49% (p=0.000 n=10)
Publish_50Subscribers_StatsLike_Pointer                          16.32µ ± 34%   16.24µ ±  1%        ~ (p=0.280 n=10)
Publish_WithTimeout_50Subscribers_StatsLike_Pointer              33.80µ ± 24%   17.99µ ±  1%  -46.77% (p=0.000 n=10)
SubscribeTopic                                                   81.06n ±  7%   74.59n ±  1%   -7.98% (p=0.000 n=10)
Publish_50Subscribers_StatsLike_TopicAssertValue                 21.20µ ±  6%   20.61µ ±  0%        ~ (p=0.353 n=10)
Publish_WithTimeout_50Subscribers_StatsLike_TopicAssertValue     33.46µ ±  7%   22.57µ ±  1%  -32.55% (p=0.000 n=10)
Publish_50Subscribers_StatsLike_TopicAssertPointer               16.17µ ±  1%   16.28µ ±  1%        ~ (p=0.165 n=10)
Publish_WithTimeout_50Subscribers_StatsLike_TopicAssertPointer   28.68µ ±  3%   18.13µ ±  0%  -36.79% (p=0.000 n=10)
geomean                                                          6.165µ         5.268µ        -14.54%

                                                               │   before.txt    │               timer.txt                │
                                                               │      B/op       │     B/op      vs base                  │
Publish_NoSubscribers                                               0.000 ± 0%       0.000 ± 0%        ~ (p=1.000 n=10) ¹
Publish_1Subscriber                                                 64.00 ± 0%       64.00 ± 0%        ~ (p=1.000 n=10) ¹
Publish_WithTimeout_1Subscriber                                     312.0 ± 0%       304.0 ± 0%   -2.56% (p=0.000 n=10)
Publish_10Subscribers                                               640.0 ± 0%       640.0 ± 0%        ~ (p=1.000 n=10) ¹
Publish_100Subscribers                                            6.250Ki ± 0%     6.250Ki ± 0%        ~ (p=1.000 n=10) ¹
Publish_1000Subscribers                                           62.50Ki ± 0%     62.50Ki ± 0%        ~ (p=1.000 n=10) ¹
Publish_WithTimeout_10Subscribers                                  3120.0 ± 0%       880.0 ± 0%  -71.79% (p=0.000 n=10)
Publish_WithTimeout_100Subscribers                               30.470Ki ± 0%     6.484Ki ± 0%  -78.72% (p=0.000 n=10)
Publish_WithTimeout_1000Subscribers                              304.76Ki ± 0%     62.74Ki ± 0%  -79.41% (p=0.000 n=10)
Publish_50Subscribers                                             3.125Ki ± 0%     3.125Ki ± 0%        ~ (p=1.000 n=10) ¹
Publish_WithTimeout_50Subscribers                                15.234Ki ± 0%     3.359Ki ± 0%  -77.95% (p=0.000 n=10)
Subscribe                                                           112.0 ± 0%       112.0 ± 0%        ~ (p=1.000 n=10) ¹
Evict                                                               0.000 ± 0%       0.000 ± 0%        ~ (p=1.000 n=10) ¹
Close_1000Subscribers                                               0.000 ± 0%       0.000 ± 0%        ~ (p=1.000 n=10) ¹
Subscribe_UnderPublishLoad                                          260.5 ± 2%       267.0 ± 9%        ~ (p=0.108 n=10)
Publish_50Subscribers_StatsLike_Value                             3.125Ki ± 0%     3.125Ki ± 0%        ~ (p=1.000 n=10) ¹
Publish_WithTimeout_50Subscribers_StatsLike_Value                15.234Ki ± 0%     3.359Ki ± 0%  -77.95% (p=0.000 n=10)
Publish_50Subscribers_StatsLike_Pointer                           3.125Ki ± 0%     3.125Ki ± 0%        ~ (p=1.000 n=10) ¹
Publish_WithTimeout_50Subscribers_StatsLike_Pointer              15.234Ki ± 0%     3.359Ki ± 0%  -77.95% (p=0.000 n=10)
SubscribeTopic                                                      112.0 ± 0%       112.0 ± 0%        ~ (p=1.000 n=10) ¹
Publish_50Subscribers_StatsLike_TopicAssertValue                  9.375Ki ± 0%     9.375Ki ± 0%        ~ (p=1.000 n=10) ¹
Publish_WithTimeout_50Subscribers_StatsLike_TopicAssertValue     21.485Ki ± 0%     9.609Ki ± 0%  -55.27% (p=0.000 n=10)
Publish_50Subscribers_StatsLike_TopicAssertPointer                3.125Ki ± 0%     3.125Ki ± 0%        ~ (p=1.000 n=10) ¹
Publish_WithTimeout_50Subscribers_StatsLike_TopicAssertPointer   15.234Ki ± 0%     3.359Ki ± 0%  -77.95% (p=0.000 n=10)
geomean                                                                        ²                 -37.41%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                                                               │  before.txt   │               timer.txt               │
                                                               │   allocs/op   │  allocs/op   vs base                  │
Publish_NoSubscribers                                             0.000 ± 0%      0.000 ± 0%        ~ (p=1.000 n=10) ¹
Publish_1Subscriber                                               1.000 ± 0%      1.000 ± 0%        ~ (p=1.000 n=10) ¹
Publish_WithTimeout_1Subscriber                                   4.000 ± 0%      4.000 ± 0%        ~ (p=1.000 n=10) ¹
Publish_10Subscribers                                             10.00 ± 0%      10.00 ± 0%        ~ (p=1.000 n=10) ¹
Publish_100Subscribers                                            100.0 ± 0%      100.0 ± 0%        ~ (p=1.000 n=10) ¹
Publish_1000Subscribers                                          1.000k ± 0%     1.000k ± 0%        ~ (p=1.000 n=10) ¹
Publish_WithTimeout_10Subscribers                                 40.00 ± 0%      13.00 ± 0%  -67.50% (p=0.000 n=10)
Publish_WithTimeout_100Subscribers                                400.0 ± 0%      103.0 ± 0%  -74.25% (p=0.000 n=10)
Publish_WithTimeout_1000Subscribers                              4.000k ± 0%     1.003k ± 0%  -74.93% (p=0.000 n=10)
Publish_50Subscribers                                             50.00 ± 0%      50.00 ± 0%        ~ (p=1.000 n=10) ¹
Publish_WithTimeout_50Subscribers                                200.00 ± 0%      53.00 ± 0%  -73.50% (p=0.000 n=10)
Subscribe                                                         1.000 ± 0%      1.000 ± 0%        ~ (p=1.000 n=10) ¹
Evict                                                             0.000 ± 0%      0.000 ± 0%        ~ (p=1.000 n=10) ¹
Close_1000Subscribers                                             0.000 ± 0%      0.000 ± 0%        ~ (p=1.000 n=10) ¹
Subscribe_UnderPublishLoad                                        3.000 ± 0%      3.000 ± 0%        ~ (p=1.000 n=10) ¹
Publish_50Subscribers_StatsLike_Value                             50.00 ± 0%      50.00 ± 0%        ~ (p=1.000 n=10) ¹
Publish_WithTimeout_50Subscribers_StatsLike_Value                200.00 ± 0%      53.00 ± 0%  -73.50% (p=0.000 n=10)
Publish_50Subscribers_StatsLike_Pointer                           50.00 ± 0%      50.00 ± 0%        ~ (p=1.000 n=10) ¹
Publish_WithTimeout_50Subscribers_StatsLike_Pointer              200.00 ± 0%      53.00 ± 0%  -73.50% (p=0.000 n=10)
SubscribeTopic                                                    1.000 ± 0%      1.000 ± 0%        ~ (p=1.000 n=10) ¹
Publish_50Subscribers_StatsLike_TopicAssertValue                  100.0 ± 0%      100.0 ± 0%        ~ (p=1.000 n=10) ¹
Publish_WithTimeout_50Subscribers_StatsLike_TopicAssertValue      250.0 ± 0%      103.0 ± 0%  -58.80% (p=0.000 n=10)
Publish_50Subscribers_StatsLike_TopicAssertPointer                50.00 ± 0%      50.00 ± 0%        ~ (p=1.000 n=10) ¹
Publish_WithTimeout_50Subscribers_StatsLike_TopicAssertPointer   200.00 ± 0%      53.00 ± 0%  -73.50% (p=0.000 n=10)
geomean                                                                      ²                -34.25%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```

[moby@434d2e8]: https://github.com/moby/moby/commit/434d2e8745696255a204d9eefc6a2854ff74e5c2